### PR TITLE
Cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,8 @@ coverage: test
 	gcovr -r . -e 'lib.*'
 
 linecheck:
-	grep -rIn --color '.\{81\}' src # limit to 80 columns
-	grep -rIn --color '.\{81\}' test # limit to 80 columns
+	-grep -rIn --color '.\{81\}' src # limit to 80 columns
+	-grep -rIn --color '.\{81\}' test # limit to 80 columns
 
 style:
 	astyle --options=.astylerc "src/*.cpp" "src/*.hpp" "test/*.cpp"

--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -2319,7 +2319,7 @@ INCLUDED_BY_GRAPH      = YES
 # The default value is: NO.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-CALL_GRAPH             = NO
+CALL_GRAPH             = YES
 
 # If the CALLER_GRAPH tag is set to YES then doxygen will generate a caller
 # dependency graph for every global function or class method.
@@ -2331,7 +2331,7 @@ CALL_GRAPH             = NO
 # The default value is: NO.
 # This tag requires that the tag HAVE_DOT is set to YES.
 
-CALLER_GRAPH           = NO
+CALLER_GRAPH           = YES
 
 # If the GRAPHICAL_HIERARCHY tag is set to YES then doxygen will graphical
 # hierarchy of all classes instead of a textual one.

--- a/src/DNSLookupError.cpp
+++ b/src/DNSLookupError.cpp
@@ -16,6 +16,7 @@
 
 
 #include <string>
+
 #include "DNSLookupError.hpp"
 
 

--- a/src/IPAddress.cpp
+++ b/src/IPAddress.cpp
@@ -189,6 +189,7 @@ IPAddress::IPAddress(std::string address)
  *
  *  \return The 32-bit IP address (in system byte order) as an integer
  *      (0x00000000 - 0xFFFFFFFF).
+ *  \complexity \f$O(1)\f$
  */
 unsigned long IPAddress::address() const
 {
@@ -199,6 +200,7 @@ unsigned long IPAddress::address() const
 /** Return the port.
  *
  *  \return The port number (0 - 65535).
+ *  \complexity \f$O(1)\f$
  */
 unsigned int IPAddress::port() const
 {
@@ -213,6 +215,7 @@ unsigned int IPAddress::port() const
  *  \param rhs The right hand side IP address.
  *  \retval true if \p lhs and \p rhs have the same address and port.
  *  \retval false if \p lhs and \p rhs do not have the same address and port.
+ *  \complexity \f$O(1)\f$
  */
 bool operator==(const IPAddress &lhs, const IPAddress &rhs)
 {
@@ -227,6 +230,7 @@ bool operator==(const IPAddress &lhs, const IPAddress &rhs)
  *  \param rhs The right hand side IP address.
  *  \retval true if \p lhs and \p rhs do not have the same address and port.
  *  \retval false if \p lhs and \p rhs have the same address and port.
+ *  \complexity \f$O(1)\f$
  */
 bool operator!=(const IPAddress &lhs, const IPAddress &rhs)
 {
@@ -243,6 +247,7 @@ bool operator!=(const IPAddress &lhs, const IPAddress &rhs)
  *  \param rhs The right hand side IP address.
  *  \retval true if \p lhs is less than \p rhs.
  *  \retval false if \p lhs is not less than \p rhs.
+ *  \complexity \f$O(1)\f$
  */
 bool operator<(const IPAddress &lhs, const IPAddress &rhs)
 {
@@ -260,6 +265,7 @@ bool operator<(const IPAddress &lhs, const IPAddress &rhs)
  *  \param rhs The right hand side IP address.
  *  \retval true if \p lhs is greater than \p rhs.
  *  \retval false if \p lhs is not greater than \p rhs.
+ *  \complexity \f$O(1)\f$
  */
 bool operator>(const IPAddress &lhs, const IPAddress &rhs)
 {
@@ -277,6 +283,7 @@ bool operator>(const IPAddress &lhs, const IPAddress &rhs)
  *  \param rhs The right hand side IP address.
  *  \retval true if \p lhs is less than or eqaul to \p rhs.
  *  \retval false if \p lhs is greater than \p rhs.
+ *  \complexity \f$O(1)\f$
  */
 bool operator<=(const IPAddress &lhs, const IPAddress &rhs)
 {
@@ -293,6 +300,7 @@ bool operator<=(const IPAddress &lhs, const IPAddress &rhs)
  *  \param rhs The right hand side IP address.
  *  \retval true if \p lhs is greater than or equal to \p rhs.
  *  \retval false if \p lhs is less than \p rhs.
+ *  \complexity \f$O(1)\f$
  */
 bool operator>=(const IPAddress &lhs, const IPAddress &rhs)
 {

--- a/src/IPAddress.cpp
+++ b/src/IPAddress.cpp
@@ -49,15 +49,17 @@ void IPAddress::construct_(unsigned long address, unsigned int port)
     if (address > 0xFFFFFFFF)
     {
         std::stringstream ss;
-        ss << "address (0x" << std::hex << address <<
-           ") is outside of the allowed range (0x00000000 - 0xffffffff).";
+        ss << "Address (0x"
+           << std::uppercase << std::hex << address << std::nouppercase
+           << ") is outside of the allowed range (0x00000000 - 0xFFFFFFFF).";
         throw std::out_of_range(ss.str());
     }
 
     if (port > 65535)
     {
-        throw std::out_of_range("port number (" + std::to_string(port) +
-                                ") is outside of the allowed range (0 - 65535).");
+        throw std::out_of_range(
+            "port number (" + std::to_string(port) +
+            ") is outside of the allowed range (0 - 65535).");
     }
 
     address_ = address;
@@ -170,8 +172,9 @@ IPAddress::IPAddress(std::string address)
     for (auto i : octets)
         if (i > 255)
         {
-            throw std::out_of_range("address octet (" + std::to_string(i) +
-                                    ") is outside of the allowed range (0 - 255).");
+            throw std::out_of_range(
+                "Address octet (" + std::to_string(i) +
+                ") is outside of the allowed range (0 - 255).");
         }
 
     {
@@ -371,15 +374,15 @@ static IPAddress unix_dnslookup(const std::string &url, unsigned int port)
         throw DNSLookupError(url);
     }
 
-    std::unique_ptr<struct addrinfo, void(*)(struct addrinfo *)> result(result_ptr,
-            freeaddrinfo);
+    std::unique_ptr<struct addrinfo, void(*)(struct addrinfo *)>
+    result(result_ptr, freeaddrinfo);
     result_ptr = nullptr;
 
     for (result_ptr = result.get(); result_ptr != nullptr;
             result_ptr = result_ptr->ai_next)
     {
-        struct sockaddr_in *address_ptr = reinterpret_cast<struct sockaddr_in *>
-                                              (result_ptr->ai_addr);
+        struct sockaddr_in *address_ptr =
+                reinterpret_cast<struct sockaddr_in *>(result_ptr->ai_addr);
         unsigned long address = ntohl(address_ptr->sin_addr.s_addr);
         addresses.insert(IPAddress(address, port));
     }

--- a/src/IPAddress.hpp
+++ b/src/IPAddress.hpp
@@ -40,6 +40,11 @@ class IPAddress
          * \param other IP address to copy.
          */
         IPAddress(const IPAddress &other) = default;
+        /** Move constructor.
+         *
+         * \param other IP address to move from.
+         */
+        IPAddress(IPAddress &&other) = default;
         IPAddress(const IPAddress &other, unsigned int port);
         IPAddress(unsigned long address, unsigned int port = 0);
         IPAddress(std::string address);
@@ -50,6 +55,11 @@ class IPAddress
          * \param other IP address to copy.
          */
         IPAddress &operator=(const IPAddress &other) = default;
+        /** Assignment operator (by move semantics).
+         *
+         * \param other IP address to move from.
+         */
+        IPAddress &operator=(IPAddress &&other) = default;
 
         friend std::ostream &operator<<(
             std::ostream &os, const IPAddress &ipaddress);

--- a/src/IPAddress.hpp
+++ b/src/IPAddress.hpp
@@ -51,8 +51,8 @@ class IPAddress
          */
         IPAddress &operator=(const IPAddress &other) = default;
 
-        friend std::ostream &operator<<(std::ostream &os,
-                                        const IPAddress &ipaddress);
+        friend std::ostream &operator<<(
+            std::ostream &os, const IPAddress &ipaddress);
 };
 
 

--- a/src/MAVAddress.cpp
+++ b/src/MAVAddress.cpp
@@ -41,8 +41,9 @@ MAVAddress::MAVAddress(unsigned int address)
 {
     if (address > 65535)
     {
-        throw std::out_of_range("address (" + std::to_string(address) +
-                                ") is outside of the allowed range (0 - 65535).");
+        throw std::out_of_range(
+            "Address (" + std::to_string(address) +
+            ") is outside of the allowed range (0 - 65535).");
     }
 
     address_ = address;
@@ -54,14 +55,16 @@ void MAVAddress::construct_(unsigned int system, unsigned int component)
 {
     if (system > 255)
     {
-        throw std::out_of_range("system id (" + std::to_string(system) +
-                                ") is outside of the allowed range (0 - 255).");
+        throw std::out_of_range(
+            "System ID (" + std::to_string(system) +
+            ") is outside of the allowed range (0 - 255).");
     }
 
     if (component > 255)
     {
-        throw std::out_of_range("component id (" + std::to_string(system) +
-                                ") is outside of the allowed range (0 - 255).");
+        throw std::out_of_range(
+            "Component ID (" + std::to_string(component) +
+            ") is outside of the allowed range (0 - 255).");
     }
 
     address_ = ((system << 8) & 0xFF00) | (component & 0x00FF);
@@ -136,6 +139,7 @@ MAVAddress::MAVAddress(std::string address)
  *
  *  \return The MAVLink address as a two byte number with the System ID encoded
  *      in the MSB and the Component ID in the LSB.
+ *  \complexity \f$O(1)\f$
  */
 unsigned int MAVAddress::address() const
 {
@@ -146,6 +150,7 @@ unsigned int MAVAddress::address() const
 /** Return the System ID.
  *
  *  \return The System ID (0 - 255).
+ *  \complexity \f$O(1)\f$
  */
 unsigned int MAVAddress::system() const
 {
@@ -156,6 +161,7 @@ unsigned int MAVAddress::system() const
 /** Return the Component ID.
  *
  *  \return The Component ID (0 - 255).
+ *  \complexity \f$O(1)\f$
  */
 unsigned int MAVAddress::component() const
 {
@@ -171,6 +177,7 @@ unsigned int MAVAddress::component() const
  *  \retval true if \p lhs and \p rhs have the same system and component ID's.
  *  \retval false if \p lhs and \p rhs do not have the same system and component
  *      ID's.
+ *  \complexity \f$O(1)\f$
  */
 bool operator==(const MAVAddress &lhs, const MAVAddress &rhs)
 {
@@ -186,6 +193,7 @@ bool operator==(const MAVAddress &lhs, const MAVAddress &rhs)
  *  \retval true if \p lhs and \p rhs do not have the same system and component
  *      ID's
  *  \retval false if \p lhs and \p rhs have the same system and component ID's.
+ *  \complexity \f$O(1)\f$
  */
 bool operator!=(const MAVAddress &lhs, const MAVAddress &rhs)
 {
@@ -202,6 +210,7 @@ bool operator!=(const MAVAddress &lhs, const MAVAddress &rhs)
  *  \param rhs The right hand side MAVLink address.
  *  \retval true if \p lhs is less than \p rhs.
  *  \retval false if \p lhs is not less than \p rhs.
+ *  \complexity \f$O(1)\f$
  */
 bool operator<(const MAVAddress &lhs, const MAVAddress &rhs)
 {
@@ -218,6 +227,7 @@ bool operator<(const MAVAddress &lhs, const MAVAddress &rhs)
  *  \param rhs The right hand side IP address.
  *  \retval true if \p lhs is greater than \p rhs.
  *  \retval false if \p lhs is not greater than \p rhs.
+ *  \complexity \f$O(1)\f$
  */
 bool operator>(const MAVAddress &lhs, const MAVAddress &rhs)
 {
@@ -234,6 +244,7 @@ bool operator>(const MAVAddress &lhs, const MAVAddress &rhs)
  *  \param rhs The right hand side IP address.
  *  \retval true if \p lhs is less than or eqaul to \p rhs.
  *  \retval false if \p lhs is greater than \p rhs.
+ *  \complexity \f$O(1)\f$
  */
 bool operator<=(const MAVAddress &lhs, const MAVAddress &rhs)
 {
@@ -250,6 +261,7 @@ bool operator<=(const MAVAddress &lhs, const MAVAddress &rhs)
  *  \param rhs The right hand side IP address.
  *  \retval true if \p lhs is greater than or equal to \p rhs.
  *  \retval false if \p lhs is less than \p rhs.
+ *  \complexity \f$O(1)\f$
  */
 bool operator>=(const MAVAddress &lhs, const MAVAddress &rhs)
 {

--- a/src/MAVAddress.hpp
+++ b/src/MAVAddress.hpp
@@ -46,6 +46,11 @@ class MAVAddress
          * \param other MAVLink address to copy.
          */
         MAVAddress(const MAVAddress &other) = default;
+        /** Move constructor.
+         *
+         * \param other MAVLink address to move from.
+         */
+        MAVAddress(MAVAddress &&other) = default;
         MAVAddress(unsigned int address);
         MAVAddress(unsigned int system, unsigned int component);
         MAVAddress(std::string address);
@@ -57,6 +62,11 @@ class MAVAddress
          * \param other MAVLink address to copy.
          */
         MAVAddress &operator=(const MAVAddress &other) = default;
+        /** Assignment operator (by move semantics).
+         *
+         * \param other MAVLink address to move from.
+         */
+        MAVAddress &operator=(MAVAddress &&other) = default;
 };
 
 

--- a/src/MAVSubnet.cpp
+++ b/src/MAVSubnet.cpp
@@ -187,6 +187,7 @@ MAVSubnet::MAVSubnet(std::string subnet)
                 throw std::invalid_argument(
                     "Invalid MAVLink subnet: \"" + subnet + "\".");
             }
+
             break;
 
         // Forward slash based subnet (bits from left).

--- a/src/MAVSubnet.hpp
+++ b/src/MAVSubnet.hpp
@@ -34,9 +34,14 @@ class MAVSubnet
     public:
         /** Copy constructor.
          *
-         * \param other MAVLink address to copy.
+         * \param other MAVLink subnet to copy.
          */
         MAVSubnet(const MAVSubnet &other) = default;
+        /** Move constructor.
+         *
+         * \param other MAVLink subnet to move from.
+         */
+        MAVSubnet(MAVSubnet &&other) = default;
         MAVSubnet(const MAVAddress &address, unsigned int mask = 0xFFFF);
         MAVSubnet(const MAVAddress &address, unsigned int system_mask,
                   unsigned int component_mask);
@@ -44,9 +49,14 @@ class MAVSubnet
         bool contains(const MAVAddress &address) const;
         /** Assignment operator.
          *
-         * \param other MAVLink address to copy.
+         * \param other MAVLink subnet to copy.
          */
         MAVSubnet &operator=(const MAVSubnet &other) = default;
+        /** Assignment operator (by move semantics).
+         *
+         * \param other MAVLink subnet to move from.
+         */
+        MAVSubnet &operator=(MAVSubnet &&other) = default;
 
         friend bool operator==(const MAVSubnet &lhs, const MAVSubnet &rhs);
         friend bool operator!=(const MAVSubnet &lhs, const MAVSubnet &rhs);

--- a/src/Packet.hpp
+++ b/src/Packet.hpp
@@ -49,6 +49,11 @@ class Packet
          * \param other Packet to copy.
          */
         Packet(const Packet &other) = default;
+        /** Move constructor.
+         *
+         * \param other Packet to move from.
+         */
+        Packet(Packet &&other) = default;
         Packet(std::vector<uint8_t> data, std::weak_ptr<Connection> connection,
                int priority = 0);
         virtual ~Packet();
@@ -94,6 +99,11 @@ class Packet
          * \param other Packet to copy.
          */
         Packet &operator=(const Packet &other) = default;
+        /** Assignment operator (by move semantics).
+         *
+         * \param other Packet to move from.
+         */
+        Packet &operator=(Packet &&other) = default;
 
 };
 

--- a/src/Packet.hpp
+++ b/src/Packet.hpp
@@ -46,12 +46,12 @@ class Packet
     public:
         /** Copy constructor.
          *
-         * \param other Packet to copy.
+         *  \param other Packet to copy.
          */
         Packet(const Packet &other) = default;
         /** Move constructor.
          *
-         * \param other Packet to move from.
+         *  \param other Packet to move from.
          */
         Packet(Packet &&other) = default;
         Packet(std::vector<uint8_t> data, std::weak_ptr<Connection> connection,
@@ -61,7 +61,7 @@ class Packet
         /** Return packet version.
          *
          *  \returns Two byte Packet version with major version in MSB and minor
-         *  version in LSB.
+         *      version in LSB.
          */
         virtual unsigned int version() const = 0;
         /** Return MAVLink message ID.
@@ -88,7 +88,7 @@ class Packet
          *  component a component ID of 0 will be used (the broadcast ID).
          *
          *  \returns The destination MAVLink address of the packet if not a
-         *  broadcast packet.
+         *      broadcast packet.
          */
         virtual std::optional<MAVAddress> dest() const = 0;
         int priority() const;
@@ -96,12 +96,12 @@ class Packet
         const std::vector<uint8_t> &data() const;
         /** Assignment operator.
          *
-         * \param other Packet to copy.
+         *  \param other Packet to copy.
          */
         Packet &operator=(const Packet &other) = default;
         /** Assignment operator (by move semantics).
          *
-         * \param other Packet to move from.
+         *  \param other Packet to move from.
          */
         Packet &operator=(Packet &&other) = default;
 

--- a/src/PacketVersion1.cpp
+++ b/src/PacketVersion1.cpp
@@ -116,9 +116,9 @@ unsigned long PacketVersion1::id() const
 
 /** \copydoc Packet::name()
  *
+ *  \throws std::runtime_error If the packet data has an invalid ID.
  *  \complexity \f$O(log(n))\f$ where \f$n\f$ is the total number of MAVLink
  *      messages.
- *  \throws std::runtime_error If the packet data has an invalid ID.
  */
 std::string PacketVersion1::name() const
 {

--- a/src/PacketVersion1.hpp
+++ b/src/PacketVersion1.hpp
@@ -42,9 +42,14 @@ class PacketVersion1 : public Packet
     public:
         /** Copy constructor.
          *
-         * \param other PacketVersion1 to copy.
+         *  \param other PacketVersion1 to copy.
          */
         PacketVersion1(const PacketVersion1 &other) = default;
+        /** Move constructor.
+         *
+         *  \param other PacketVersion1 to move from.
+         */
+        PacketVersion1(PacketVersion1 &&other) = default;
         PacketVersion1(
             std::vector<uint8_t> data,
             std::weak_ptr<Connection> connection,
@@ -56,9 +61,14 @@ class PacketVersion1 : public Packet
         virtual std::optional<MAVAddress> dest() const;
         /** Assignment operator.
          *
-         * \param other PacketVersion1 to copy.
+         *  \param other PacketVersion1 to copy.
          */
         PacketVersion1 &operator=(const PacketVersion1 &other) = default;
+        /** Assignment operator (by move semantics).
+         *
+         *  \param other PacketVersion1 to move from.
+         */
+        PacketVersion1 &operator=(PacketVersion1 &&other) = default;
 };
 
 

--- a/src/PacketVersion2.cpp
+++ b/src/PacketVersion2.cpp
@@ -119,9 +119,9 @@ unsigned long PacketVersion2::id() const
 
 /** \copydoc Packet::name()
  *
+ *  \throws std::runtime_error If the packet data has an invalid ID.
  *  \complexity \f$O(log(n))\f$ where \f$n\f$ is the total number of MAVLink
  *      messages.
- *  \throws std::runtime_error If the packet data has an invalid ID.
  */
 std::string PacketVersion2::name() const
 {
@@ -151,11 +151,11 @@ MAVAddress PacketVersion2::source() const
 
 /** \copydoc Packet::dest()
  *
+ *  \throws std::runtime_error If the packet data has an invalid ID.
  *  \complexity \f$O(1)\f$
  *  \thanks The [mavlink-router](https://github.com/intel/mavlink-router)
  *      project for an example of how to extract the destination address.
  *
- *  \throws std::runtime_error If the packet data has an invalid ID.
  */
 std::optional<MAVAddress> PacketVersion2::dest() const
 {

--- a/src/PacketVersion2.hpp
+++ b/src/PacketVersion2.hpp
@@ -42,9 +42,14 @@ class PacketVersion2 : public Packet
     public:
         /** Copy constructor.
          *
-         * \param other PacketVersion2 to copy.
+         *  \param other PacketVersion2 to copy.
          */
         PacketVersion2(const PacketVersion2 &other) = default;
+        /** Move constructor.
+         *
+         *  \param other PacketVersion2 to move from.
+         */
+        PacketVersion2(PacketVersion2 &&other) = default;
         PacketVersion2(
             std::vector<uint8_t> data,
             std::weak_ptr<Connection> connection,
@@ -56,9 +61,14 @@ class PacketVersion2 : public Packet
         virtual std::optional<MAVAddress> dest() const;
         /** Assignment operator.
          *
-         * \param other PacketVersion2 to copy.
+         *  \param other PacketVersion2 to copy.
          */
         PacketVersion2 &operator=(const PacketVersion2 &other) = default;
+        /** Assignment operator (by move semantics).
+         *
+         *  \param other PacketVersion2 to move from.
+         */
+        PacketVersion2 &operator=(PacketVersion2 &&other) = default;
 };
 
 

--- a/src/mavtables.cpp
+++ b/src/mavtables.cpp
@@ -28,5 +28,5 @@ int main(int argc, char **argv)
               << VERSION_MAJOR << "."
               << VERSION_MINOR << "."
               << VERSION_PATCH << std::endl;
-    std::cout << capital_case("a MAVLink router and firewall.") << std::endl;
+    std::cout << "A MAVLink router and firewall." << std::endl;
 }

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -15,8 +15,6 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-#include <string>
-#include <cctype>
 #include "util.hpp"
 
 
@@ -24,14 +22,3 @@
  *
  *  Utility functions that don't warrant their own file.
  */
-
-
-/** \brief Capitalize first letter of a string.
- *  \ingroup utility
- *  \bug Index error if given an empty string.
- */
-std::string capital_case(std::string str)
-{
-    str[0] = static_cast<char>(toupper(str[0]));
-    return str;
-}

--- a/src/util.cpp
+++ b/src/util.cpp
@@ -18,7 +18,7 @@
 #include "util.hpp"
 
 
-/** \defgroup utility Utility Function
+/** \defgroup utility Utility Functions
  *
  *  Utility functions that don't warrant their own file.
  */

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -24,16 +24,15 @@
 #include <boost/range/irange.hpp>
 
 
-std::string capital_case(std::string str);
-
-
 /** Convert numeric types to bytes.
  *
- * \ingroup utility
- * \tparam ByteType Numeric type to return in the array of bytes.
- * \tparam T Type of the number being converted to bytes.
- * \param number Number to convert to bytes
- * \return The array of bytes from the given number, in LSB order.
+ *  \ingroup utility
+ *  \tparam ByteType Numeric type to return in the array of bytes.
+ *  \tparam T Type of the number being converted to bytes.
+ *  \param number Number to convert to bytes
+ *  \return The array of bytes from the given number, in LSB order.
+ *  \complexity \f$O(n)\f$ where \f$n\f$ is the number of bytes in type
+ *      \ref T.
  */
 template <class ByteType = unsigned char, class T>
 std::array<ByteType, sizeof(T)> to_bytes(T number)
@@ -52,10 +51,10 @@ std::array<ByteType, sizeof(T)> to_bytes(T number)
 
 /** Convert any object supporting the output stream operator (<<) to a string.
  *
- * \ingroup utility
- * \tparam T Type of the object to convert to a string.
- * \param object The object to convert to a string.
- * \return The string representing the object.
+ *  \ingroup utility
+ *  \tparam T Type of the object to convert to a string.
+ *  \param object The object to convert to a string.
+ *  \return The string representing the object.
  */
 template <class T>
 std::string str(const T &object)

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -31,8 +31,7 @@
  *  \tparam T Type of the number being converted to bytes.
  *  \param number Number to convert to bytes
  *  \return The array of bytes from the given number, in LSB order.
- *  \complexity \f$O(n)\f$ where \f$n\f$ is the number of bytes in type
- *      \ref T.
+ *  \complexity \f$O(n)\f$ where \f$n\f$ is the number of bytes in type \p T.
  */
 template <class ByteType = unsigned char, class T>
 std::array<ByteType, sizeof(T)> to_bytes(T number)

--- a/test/test_DNSLookupError.cpp
+++ b/test/test_DNSLookupError.cpp
@@ -1,5 +1,5 @@
 // MAVLink router and firewall.
-// Copyright (C) 2017  Michael R. Shannon <mrshannon.aerospace@gmail.com>
+// Copyright (C) 2017-2018  Michael R. Shannon <mrshannon.aerospace@gmail.com>
 //
 // This program is free software; you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -17,7 +17,9 @@
 
 #include <string>
 #include <exception>
+
 #include <catch.hpp>
+
 #include "DNSLookupError.hpp"
 
 
@@ -27,24 +29,25 @@
 }
 
 
-TEST_CASE("DNSLookupError's can be thrown", "[error]")
+TEST_CASE("DNSLookupError's can be thrown.", "[DNSLookupError]")
 {
-    SECTION("can be caught")
+    SECTION("And can be caught.")
     {
         REQUIRE_THROWS(throw_lookup_error("example.com"));
     }
-    SECTION("can be caught as GNSLookupError")
+    SECTION("And can be caught as DNSLookupError.")
     {
         REQUIRE_THROWS_AS(throw_lookup_error("example.com"), DNSLookupError);
     }
-    SECTION("can be caught as std::exception")
+    SECTION("And can be caught as std::exception.")
     {
         REQUIRE_THROWS_AS(throw_lookup_error("example.com"), std::exception);
     }
 }
 
 
-TEST_CASE("'what' method gives unresolved hostname", "[error]")
+TEST_CASE("The 'what' method gives the unresolved hostname.",
+          "[DNSLookupError]")
 {
     REQUIRE(std::string(DNSLookupError("example.com").what()) ==
             "DNSLookupError: Could not find an IP address for \"example.com\"");

--- a/test/test_IPAddress.cpp
+++ b/test/test_IPAddress.cpp
@@ -15,6 +15,9 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
+#include <utility>
+#include <stdexcept>
+
 #include <catch.hpp>
 
 #include "util.hpp"

--- a/test/test_IPAddress.cpp
+++ b/test/test_IPAddress.cpp
@@ -16,7 +16,8 @@
 
 
 #include <catch.hpp>
-#include <sstream>
+
+#include "util.hpp"
 #include "IPAddress.hpp"
 
 
@@ -40,8 +41,10 @@ TEST_CASE("IPAddress's are comparable.", "[IPAddress]")
         REQUIRE(IPAddress(0xFFFFFFFF, 65535) == IPAddress(0xFFFFFFFF, 65535));
         REQUIRE_FALSE(IPAddress(0x00000000, 0) == IPAddress(0x00000000, 1));
         REQUIRE_FALSE(IPAddress(0x00000000, 0) == IPAddress(0x00000001, 0));
-        REQUIRE_FALSE(IPAddress(0xFFFFFFFF, 65535) == IPAddress(0xFFFFFFFF, 65534));
-        REQUIRE_FALSE(IPAddress(0xFFFFFFFF, 65535) == IPAddress(0xFFFFFFFE, 65535));
+        REQUIRE_FALSE(
+            IPAddress(0xFFFFFFFF, 65535) == IPAddress(0xFFFFFFFF, 65534));
+        REQUIRE_FALSE(
+            IPAddress(0xFFFFFFFF, 65535) == IPAddress(0xFFFFFFFE, 65535));
     }
     SECTION("with !=")
     {
@@ -51,7 +54,8 @@ TEST_CASE("IPAddress's are comparable.", "[IPAddress]")
         REQUIRE(IPAddress(0xFFFFFFFF, 65535) != IPAddress(0xFFFFFFFE, 65535));
         REQUIRE_FALSE(IPAddress(0x00000000, 0) != IPAddress(0x00000000, 0));
         REQUIRE_FALSE(IPAddress(0x88888888, 8) != IPAddress(0x88888888, 8));
-        REQUIRE_FALSE(IPAddress(0xFFFFFFFF, 65535) != IPAddress(0xFFFFFFFF, 65535));
+        REQUIRE_FALSE(
+            IPAddress(0xFFFFFFFF, 65535) != IPAddress(0xFFFFFFFF, 65535));
     }
     SECTION("with <")
     {
@@ -64,11 +68,14 @@ TEST_CASE("IPAddress's are comparable.", "[IPAddress]")
         REQUIRE_FALSE(IPAddress(0x00000000, 1) < IPAddress(0x00000000, 0));
         REQUIRE_FALSE(IPAddress(0x00000001, 0) < IPAddress(0x00000000, 0));
         REQUIRE_FALSE(IPAddress(0x00000001, 0) < IPAddress(0x00000000, 1));
-        REQUIRE_FALSE(IPAddress(0xFFFFFFFF, 65535) < IPAddress(0xFFFFFFFF, 65534));
-        REQUIRE_FALSE(IPAddress(0xFFFFFFFF, 65535) < IPAddress(0xFFFFFFFE, 65535));
+        REQUIRE_FALSE(
+            IPAddress(0xFFFFFFFF, 65535) < IPAddress(0xFFFFFFFF, 65534));
+        REQUIRE_FALSE(
+            IPAddress(0xFFFFFFFF, 65535) < IPAddress(0xFFFFFFFE, 65535));
         REQUIRE_FALSE(IPAddress(0x00000000, 0) < IPAddress(0x00000000, 0));
         REQUIRE_FALSE(IPAddress(0x88888888, 8) < IPAddress(0x88888888, 8));
-        REQUIRE_FALSE(IPAddress(0xFFFFFFFF, 65535) < IPAddress(0xFFFFFFFF, 65535));
+        REQUIRE_FALSE(
+            IPAddress(0xFFFFFFFF, 65535) < IPAddress(0xFFFFFFFF, 65535));
         REQUIRE_FALSE(IPAddress(0xFFFFFFFF, 65535) < IPAddress(0x00000000, 0));
     }
     SECTION("with >")
@@ -82,11 +89,14 @@ TEST_CASE("IPAddress's are comparable.", "[IPAddress]")
         REQUIRE_FALSE(IPAddress(0x00000000, 0) > IPAddress(0x00000000, 1));
         REQUIRE_FALSE(IPAddress(0x00000000, 0) > IPAddress(0x00000001, 0));
         REQUIRE_FALSE(IPAddress(0x00000000, 1) > IPAddress(0x00000001, 0));
-        REQUIRE_FALSE(IPAddress(0xFFFFFFFF, 65534) > IPAddress(0xFFFFFFFF, 65535));
-        REQUIRE_FALSE(IPAddress(0xFFFFFFFE, 65535) > IPAddress(0xFFFFFFFF, 65535));
+        REQUIRE_FALSE(
+            IPAddress(0xFFFFFFFF, 65534) > IPAddress(0xFFFFFFFF, 65535));
+        REQUIRE_FALSE(
+            IPAddress(0xFFFFFFFE, 65535) > IPAddress(0xFFFFFFFF, 65535));
         REQUIRE_FALSE(IPAddress(0x00000000, 0) > IPAddress(0x00000000, 0));
         REQUIRE_FALSE(IPAddress(0x88888888, 8) > IPAddress(0x88888888, 8));
-        REQUIRE_FALSE(IPAddress(0xFFFFFFFF, 65535) > IPAddress(0xFFFFFFFF, 65535));
+        REQUIRE_FALSE(
+            IPAddress(0xFFFFFFFF, 65535) > IPAddress(0xFFFFFFFF, 65535));
         REQUIRE_FALSE(IPAddress(0x00000000, 0) > IPAddress(0xFFFFFFFF, 65535));
     }
     SECTION("with <=")
@@ -103,8 +113,10 @@ TEST_CASE("IPAddress's are comparable.", "[IPAddress]")
         REQUIRE_FALSE(IPAddress(0x00000000, 1) <= IPAddress(0x00000000, 0));
         REQUIRE_FALSE(IPAddress(0x00000001, 0) <= IPAddress(0x00000000, 0));
         REQUIRE_FALSE(IPAddress(0x00000001, 0) <= IPAddress(0x00000000, 1));
-        REQUIRE_FALSE(IPAddress(0xFFFFFFFF, 65535) <= IPAddress(0xFFFFFFFF, 65534));
-        REQUIRE_FALSE(IPAddress(0xFFFFFFFF, 65535) <= IPAddress(0xFFFFFFFE, 65535));
+        REQUIRE_FALSE(
+            IPAddress(0xFFFFFFFF, 65535) <= IPAddress(0xFFFFFFFF, 65534));
+        REQUIRE_FALSE(
+            IPAddress(0xFFFFFFFF, 65535) <= IPAddress(0xFFFFFFFE, 65535));
         REQUIRE_FALSE(IPAddress(0xFFFFFFFF, 65535) <= IPAddress(0x00000000, 0));
     }
     SECTION("with >=")
@@ -121,8 +133,10 @@ TEST_CASE("IPAddress's are comparable.", "[IPAddress]")
         REQUIRE_FALSE(IPAddress(0x00000000, 0) >= IPAddress(0x00000000, 1));
         REQUIRE_FALSE(IPAddress(0x00000000, 0) >= IPAddress(0x00000001, 0));
         REQUIRE_FALSE(IPAddress(0x00000000, 1) >= IPAddress(0x00000001, 0));
-        REQUIRE_FALSE(IPAddress(0xFFFFFFFF, 65534) >= IPAddress(0xFFFFFFFF, 65535));
-        REQUIRE_FALSE(IPAddress(0xFFFFFFFE, 65535) >= IPAddress(0xFFFFFFFF, 65535));
+        REQUIRE_FALSE(
+            IPAddress(0xFFFFFFFF, 65534) >= IPAddress(0xFFFFFFFF, 65535));
+        REQUIRE_FALSE(
+            IPAddress(0xFFFFFFFE, 65535) >= IPAddress(0xFFFFFFFF, 65535));
         REQUIRE_FALSE(IPAddress(0x00000000, 0) >= IPAddress(0xFFFFFFFF, 65535));
     }
 }
@@ -136,10 +150,10 @@ TEST_CASE("IPAddress's can be constructed from an address and port.",
     REQUIRE(IPAddress(0xFFFFFFFF, 65535) == IPAddress(0xFFFFFFFF, 65535));
     SECTION("And ensures address and port are within range.")
     {
-        REQUIRE_THROWS_AS(IPAddress(static_cast<unsigned long>(-1), 0),
-                          std::out_of_range);
-        REQUIRE_THROWS_AS(IPAddress(0, static_cast<unsigned int>(-1)),
-                          std::out_of_range);
+        REQUIRE_THROWS_AS(
+            IPAddress(static_cast<unsigned long>(-1), 0), std::out_of_range);
+        REQUIRE_THROWS_AS(
+            IPAddress(0, static_cast<unsigned int>(-1)), std::out_of_range);
         REQUIRE_THROWS_AS(IPAddress(0x1FFFFFFFF, 65535), std::out_of_range);
         REQUIRE_THROWS_AS(IPAddress(0xFFFFFFFF, 65536), std::out_of_range);
     }
@@ -158,6 +172,7 @@ TEST_CASE("IPAddress's can be constructed from strings.", "[IPAddress]")
     }
     SECTION("And will raise std::invalid_argument if it cannot be parsed.")
     {
+        // Errors.
         REQUIRE_THROWS_AS(IPAddress("-1.2.3.4"), std::invalid_argument);
         REQUIRE_THROWS_AS(IPAddress("1.-2.3.4"), std::invalid_argument);
         REQUIRE_THROWS_AS(IPAddress("1.2.-3.4"), std::invalid_argument);
@@ -178,19 +193,85 @@ TEST_CASE("IPAddress's can be constructed from strings.", "[IPAddress]")
         REQUIRE_THROWS_AS(IPAddress("1.b.3.4"), std::invalid_argument);
         REQUIRE_THROWS_AS(IPAddress("1.2.c.4"), std::invalid_argument);
         REQUIRE_THROWS_AS(IPAddress("1.2.3.d"), std::invalid_argument);
-        REQUIRE_THROWS_AS(IPAddress("192.168.32.128.443"), std::invalid_argument);
+        REQUIRE_THROWS_AS(
+            IPAddress("192.168.32.128.443"), std::invalid_argument);
         REQUIRE_THROWS_AS(IPAddress("192.168.128:443"), std::invalid_argument);
-        REQUIRE_THROWS_AS(IPAddress("192:168:32:128:443"), std::invalid_argument);
-        REQUIRE_THROWS_AS(IPAddress("192.1b8.32.128:443"), std::invalid_argument);
+        REQUIRE_THROWS_AS(
+            IPAddress("192:168:32:128:443"), std::invalid_argument);
+        REQUIRE_THROWS_AS(
+            IPAddress("192.1b8.32.128:443"), std::invalid_argument);
+        // Check error string.
+        REQUIRE_THROWS_WITH(
+            IPAddress("-1.2.3.4"), "Invalid IP address string.");
+        REQUIRE_THROWS_WITH(
+            IPAddress("1.-2.3.4"), "Invalid IP address string.");
+        REQUIRE_THROWS_WITH(
+            IPAddress("1.2.-3.4"), "Invalid IP address string.");
+        REQUIRE_THROWS_WITH(
+            IPAddress("1.2.3.-4"), "Invalid IP address string.");
+        REQUIRE_THROWS_WITH(
+            IPAddress("+1.2.3.4"), "Invalid IP address string.");
+        REQUIRE_THROWS_WITH(
+            IPAddress("1.+2.3.4"), "Invalid IP address string.");
+        REQUIRE_THROWS_WITH(
+            IPAddress("1.2.+3.4"), "Invalid IP address string.");
+        REQUIRE_THROWS_WITH(
+            IPAddress("1.2.3.+4"), "Invalid IP address string.");
+        REQUIRE_THROWS_WITH(
+            IPAddress("1"), "Invalid IP address string.");
+        REQUIRE_THROWS_WITH(
+            IPAddress("1."), "Invalid IP address string.");
+        REQUIRE_THROWS_WITH(
+            IPAddress("1.2"), "Invalid IP address string.");
+        REQUIRE_THROWS_WITH(
+            IPAddress("1.2."), "Invalid IP address string.");
+        REQUIRE_THROWS_WITH(
+            IPAddress("1.2.3"), "Invalid IP address string.");
+        REQUIRE_THROWS_WITH(
+            IPAddress("1.2.3."), "Invalid IP address string.");
+        REQUIRE_THROWS_WITH(
+            IPAddress("1.2.3.4."), "Invalid IP address string.");
+        REQUIRE_THROWS_WITH(
+            IPAddress("1.2.3.4.5"), "Invalid IP address string.");
+        REQUIRE_THROWS_WITH(
+            IPAddress("a.2.3.4"), "Invalid IP address string.");
+        REQUIRE_THROWS_WITH(
+            IPAddress("1.b.3.4"), "Invalid IP address string.");
+        REQUIRE_THROWS_WITH(
+            IPAddress("1.2.c.4"), "Invalid IP address string.");
+        REQUIRE_THROWS_WITH(
+            IPAddress("1.2.3.d"), "Invalid IP address string.");
+        REQUIRE_THROWS_WITH(
+            IPAddress("192.168.32.128.443"), "Invalid IP address string.");
+        REQUIRE_THROWS_WITH(
+            IPAddress("192.168.128:443"), "Invalid IP address string.");
+        REQUIRE_THROWS_WITH(
+            IPAddress("192:168:32:128:443"), "Invalid IP address string.");
+        REQUIRE_THROWS_WITH(
+            IPAddress("192.1b8.32.128:443"), "Invalid IP address string.");
     }
     SECTION("And ensures address and port are within range.")
     {
+        // Errors
         REQUIRE_THROWS_AS(IPAddress("1.2.3.4:-1"), std::out_of_range);
         REQUIRE_THROWS_AS(IPAddress("1.2.3.4:65536"), std::out_of_range);
         REQUIRE_THROWS_AS(IPAddress("256.2.3.4"), std::out_of_range);
         REQUIRE_THROWS_AS(IPAddress("1.256.3.4"), std::out_of_range);
         REQUIRE_THROWS_AS(IPAddress("1.2.256.4"), std::out_of_range);
         REQUIRE_THROWS_AS(IPAddress("1.2.3.256"), std::out_of_range);
+        // Check error string.
+        REQUIRE_THROWS_WITH(
+            IPAddress("256.2.3.4"),
+            "Address octet (256) is outside of the allowed range (0 - 255).");
+        REQUIRE_THROWS_WITH(
+            IPAddress("1.256.3.4"),
+            "Address octet (256) is outside of the allowed range (0 - 255).");
+        REQUIRE_THROWS_WITH(
+            IPAddress("1.2.256.4"),
+            "Address octet (256) is outside of the allowed range (0 - 255).");
+        REQUIRE_THROWS_WITH(
+            IPAddress("1.2.3.256"),
+            "Address octet (256) is outside of the allowed range (0 - 255).");
     }
 }
 
@@ -225,10 +306,10 @@ TEST_CASE("The port of an IP address can be changed during a copy.",
     REQUIRE(b_copy.port() == 0);
     SECTION("And ensures port number is within range.")
     {
-        REQUIRE_THROWS_AS(IPAddress(a, static_cast<unsigned int>(-1)),
-                          std::out_of_range);
-        REQUIRE_THROWS_AS(IPAddress(b, static_cast<unsigned int>(-1)),
-                          std::out_of_range);
+        REQUIRE_THROWS_AS(
+            IPAddress(a, static_cast<unsigned int>(-1)), std::out_of_range);
+        REQUIRE_THROWS_AS(
+            IPAddress(b, static_cast<unsigned int>(-1)), std::out_of_range);
         REQUIRE_THROWS_AS(IPAddress(a, 65536), std::out_of_range);
         REQUIRE_THROWS_AS(IPAddress(b, 65536), std::out_of_range);
     }
@@ -246,16 +327,13 @@ TEST_CASE("IPAddress's are assignable.", "[IPAddress]")
 
 TEST_CASE("IPAddress's are printable", "[IPAddress]")
 {
-    std::ostringstream oss;
     SECTION("Without a port number.")
     {
-        oss << IPAddress("192.168.32.128");
-        REQUIRE(oss.str() == "192.168.32.128");
+        REQUIRE(str(IPAddress("192.168.32.128")) == "192.168.32.128");
     }
     SECTION("With a port number.")
     {
-        oss << IPAddress("192.168.32.128:443");
-        REQUIRE(oss.str() == "192.168.32.128:443");
+        REQUIRE(str(IPAddress("192.168.32.128:443")) == "192.168.32.128:443");
     }
 }
 

--- a/test/test_IPAddress.cpp
+++ b/test/test_IPAddress.cpp
@@ -316,11 +316,33 @@ TEST_CASE("The port of an IP address can be changed during a copy.",
 }
 
 
+TEST_CASE("IPAddress's are movable.", "[IPAddress]")
+{
+    IPAddress a(0x00000000, 0);
+    IPAddress b(0xFFFFFFFF, 65535);
+    IPAddress a_moved = std::move(a);
+    IPAddress b_moved(std::move(b));
+    REQUIRE(a_moved == IPAddress(0x00000000, 0));
+    REQUIRE(b_moved == IPAddress(0xFFFFFFFF, 65535));
+}
+
+
 TEST_CASE("IPAddress's are assignable.", "[IPAddress]")
 {
     IPAddress a(0x00000000, 0);
+    IPAddress b(0xFFFFFFFF, 65535);
     REQUIRE(a == IPAddress(0x00000000, 0));
-    a = IPAddress(0xFFFFFFFF, 65535);
+    a = b;
+    REQUIRE(a == IPAddress(0xFFFFFFFF, 65535));
+}
+
+
+TEST_CASE("IPAddress's are assignable (by move semantics).", "[IPAddress]")
+{
+    IPAddress a(0x00000000, 0);
+    IPAddress b(0xFFFFFFFF, 65535);
+    REQUIRE(a == IPAddress(0x00000000, 0));
+    a = std::move(b);
     REQUIRE(a == IPAddress(0xFFFFFFFF, 65535));
 }
 

--- a/test/test_MAVAddress.cpp
+++ b/test/test_MAVAddress.cpp
@@ -15,8 +15,10 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-#include <catch.hpp>
+#include <utility>
 #include <stdexcept>
+
+#include <catch.hpp>
 
 #include "util.hpp"
 #include "MAVAddress.hpp"
@@ -272,11 +274,33 @@ TEST_CASE("MAVAddress's are copyable.", "[MAVAddress]")
 }
 
 
+TEST_CASE("MAVAddress's are movable.", "[MAVAddress]")
+{
+    MAVAddress a(0, 0);
+    MAVAddress b(255, 255);
+    MAVAddress a_moved = std::move(a);
+    MAVAddress b_moved(std::move(b));
+    REQUIRE(a_moved == MAVAddress(0, 0));
+    REQUIRE(b_moved == MAVAddress(255, 255));
+}
+
+
 TEST_CASE("MAVAddress's are assignable.", "[MAVAddress]")
 {
     MAVAddress a(0, 0);
+    MAVAddress b(255, 255);
     REQUIRE(a == MAVAddress(0, 0));
-    a = MAVAddress(255, 255);
+    a = b;
+    REQUIRE(a == MAVAddress(255, 255));
+}
+
+
+TEST_CASE("MAVAddress's are assignable (by move semantics).", "[MAVAddress]")
+{
+    MAVAddress a(0, 0);
+    MAVAddress b(255, 255);
+    REQUIRE(a == MAVAddress(0, 0));
+    a = std::move(b);
     REQUIRE(a == MAVAddress(255, 255));
 }
 

--- a/test/test_MAVAddress.cpp
+++ b/test/test_MAVAddress.cpp
@@ -16,9 +16,9 @@
 
 
 #include <catch.hpp>
-#include <sstream>
 #include <stdexcept>
 
+#include "util.hpp"
 #include "MAVAddress.hpp"
 
 
@@ -169,6 +169,7 @@ TEST_CASE("MAVAddress's can be constructed from System and Component ID's.",
     REQUIRE(MAVAddress(255, 255) == MAVAddress(0xFFFF));
     SECTION("And ensures System and Component ID's are within range.")
     {
+        // Errors
         REQUIRE_THROWS_AS(MAVAddress(static_cast<unsigned int>(-1), 0),
                           std::out_of_range);
         REQUIRE_THROWS_AS(MAVAddress(0, static_cast<unsigned int>(-1)),
@@ -176,6 +177,15 @@ TEST_CASE("MAVAddress's can be constructed from System and Component ID's.",
         REQUIRE_THROWS_AS(MAVAddress(256, 255), std::out_of_range);
         REQUIRE_THROWS_AS(MAVAddress(255, 256), std::out_of_range);
         REQUIRE_THROWS_AS(MAVAddress(256, 256), std::out_of_range);
+        // Error messages.
+        REQUIRE_THROWS_WITH(
+            MAVAddress(256, 255),
+            "System ID (256) is outside of the allowed range (0 - 255).");
+        REQUIRE_THROWS_WITH(
+            MAVAddress(255, 256),
+            "Component ID (256) is outside of the allowed range (0 - 255).");
+        // NOTE: MAVAddress(256, 256) is not checked because the order of
+        //       checking the inputs is not defined.
     }
 }
 
@@ -194,6 +204,7 @@ TEST_CASE("MAVAddress's can be constructed from strings.", "[MAVAddress]")
     REQUIRE(MAVAddress("192.168") == MAVAddress(192, 168));
     SECTION("And ensures the address string is valid.")
     {
+        // Errors
         REQUIRE_THROWS_AS(MAVAddress("1"), std::invalid_argument);
         REQUIRE_THROWS_AS(MAVAddress("1."), std::invalid_argument);
         REQUIRE_THROWS_AS(MAVAddress("1.2."), std::invalid_argument);
@@ -205,12 +216,45 @@ TEST_CASE("MAVAddress's can be constructed from strings.", "[MAVAddress]")
         REQUIRE_THROWS_AS(MAVAddress("0.+1"), std::invalid_argument);
         REQUIRE_THROWS_AS(MAVAddress("-1.0"), std::invalid_argument);
         REQUIRE_THROWS_AS(MAVAddress("0.-1"), std::invalid_argument);
+        // Error message.
+        REQUIRE_THROWS_WITH(
+            MAVAddress("1"), "Invalid MAVLink address string.");
+        REQUIRE_THROWS_WITH(
+            MAVAddress("1."), "Invalid MAVLink address string.");
+        REQUIRE_THROWS_WITH(
+            MAVAddress("1.2."), "Invalid MAVLink address string.");
+        REQUIRE_THROWS_WITH(
+            MAVAddress("1.2.3"), "Invalid MAVLink address string.");
+        REQUIRE_THROWS_WITH(
+            MAVAddress("a.2.3"), "Invalid MAVLink address string.");
+        REQUIRE_THROWS_WITH(
+            MAVAddress("1.b.3"), "Invalid MAVLink address string.");
+        REQUIRE_THROWS_WITH(
+            MAVAddress("1.2.c"), "Invalid MAVLink address string.");
+        REQUIRE_THROWS_WITH(
+            MAVAddress("+1.0"), "Invalid MAVLink address string.");
+        REQUIRE_THROWS_WITH(
+            MAVAddress("0.+1"), "Invalid MAVLink address string.");
+        REQUIRE_THROWS_WITH(
+            MAVAddress("-1.0"), "Invalid MAVLink address string.");
+        REQUIRE_THROWS_WITH(
+            MAVAddress("0.-1"), "Invalid MAVLink address string.");
     }
     SECTION("And ensures System and Component ID's are within range.")
     {
+        // Errors
         REQUIRE_THROWS_AS(MAVAddress("256.255"), std::out_of_range);
         REQUIRE_THROWS_AS(MAVAddress("255.256"), std::out_of_range);
         REQUIRE_THROWS_AS(MAVAddress("256.256"), std::out_of_range);
+        // Error messages.
+        REQUIRE_THROWS_WITH(
+            MAVAddress("256.255"),
+            "System ID (256) is outside of the allowed range (0 - 255).");
+        REQUIRE_THROWS_WITH(
+            MAVAddress("255.256"),
+            "Component ID (256) is outside of the allowed range (0 - 255).");
+        // NOTE: MAVAddress("256.256") is not checked because the order of
+        //       checking the inputs is not defined.
     }
 }
 
@@ -239,15 +283,12 @@ TEST_CASE("MAVAddress's are assignable.", "[MAVAddress]")
 
 TEST_CASE("MAVAddress's are printable", "[MAVAddress]")
 {
-    std::ostringstream oss;
     SECTION("192.168")
     {
-        oss << MAVAddress(192, 168);
-        REQUIRE(oss.str() == "192.168");
+        REQUIRE(str(MAVAddress(192, 168)) == "192.168");
     }
     SECTION("32.128")
     {
-        oss << MAVAddress(32, 128);
-        REQUIRE(oss.str() == "32.128");
+        REQUIRE(str(MAVAddress(32, 128)) == "32.128");
     }
 }

--- a/test/test_MAVSubnet.cpp
+++ b/test/test_MAVSubnet.cpp
@@ -86,7 +86,7 @@ TEST_CASE("MAVSubnet's can be constructed from a MAVLink address "
                       static_cast<unsigned int>(0x0000 - 1)),
             std::out_of_range);
         REQUIRE_THROWS_AS(
-                MAVSubnet(MAVAddress(0x0000), 0xFFFF + 1), std::out_of_range);
+            MAVSubnet(MAVAddress(0x0000), 0xFFFF + 1), std::out_of_range);
     }
 }
 

--- a/test/test_MAVSubnet.cpp
+++ b/test/test_MAVSubnet.cpp
@@ -27,173 +27,163 @@ TEST_CASE("MAVSubnet's are comparable.", "[MAVSubnet]")
 {
     SECTION("with ==")
     {
-        REQUIRE(MAVSubnet(MAVAddress(0x0000), 0x0000) == MAVSubnet(MAVAddress(0x0000),
-                0x0000));
-        REQUIRE(MAVSubnet(MAVAddress(0x1234), 0x5678) == MAVSubnet(MAVAddress(0x1234),
-                0x5678));
-        REQUIRE(MAVSubnet(MAVAddress(0xFFFF), 0xFFFF) == MAVSubnet(MAVAddress(0xFFFF),
-                0xFFFF));
-        REQUIRE_FALSE(MAVSubnet(MAVAddress(0x0000),
-                                0x0000) == MAVSubnet(MAVAddress(0x0001), 0x0000));
-        REQUIRE_FALSE(MAVSubnet(MAVAddress(0x0000),
-                                0x0000) == MAVSubnet(MAVAddress(0x0000), 0x0001));
-        REQUIRE_FALSE(MAVSubnet(MAVAddress(0x1234),
-                                0x5678) == MAVSubnet(MAVAddress(0x1235), 0x5678));
-        REQUIRE_FALSE(MAVSubnet(MAVAddress(0x1234),
-                                0x5678) == MAVSubnet(MAVAddress(0x1234), 0x5679));
-        REQUIRE_FALSE(MAVSubnet(MAVAddress(0xFFFF),
-                                0xFFFF) == MAVSubnet(MAVAddress(0xFFFE), 0xFFFF));
-        REQUIRE_FALSE(MAVSubnet(MAVAddress(0xFFFF),
-                                0xFFFF) == MAVSubnet(MAVAddress(0xFFFF), 0xFFFE));
+        REQUIRE(MAVSubnet(MAVAddress(0x0000), 0x0000) ==
+                MAVSubnet(MAVAddress(0x0000), 0x0000));
+        REQUIRE(MAVSubnet(MAVAddress(0x1234), 0x5678) ==
+                MAVSubnet(MAVAddress(0x1234), 0x5678));
+        REQUIRE(MAVSubnet(MAVAddress(0xFFFF), 0xFFFF) ==
+                MAVSubnet(MAVAddress(0xFFFF), 0xFFFF));
+        REQUIRE_FALSE(MAVSubnet(MAVAddress(0x0000), 0x0000) ==
+                      MAVSubnet(MAVAddress(0x0001), 0x0000));
+        REQUIRE_FALSE(MAVSubnet(MAVAddress(0x0000), 0x0000) ==
+                      MAVSubnet(MAVAddress(0x0000), 0x0001));
+        REQUIRE_FALSE(MAVSubnet(MAVAddress(0x1234), 0x5678) ==
+                      MAVSubnet(MAVAddress(0x1235), 0x5678));
+        REQUIRE_FALSE(MAVSubnet(MAVAddress(0x1234), 0x5678) ==
+                      MAVSubnet(MAVAddress(0x1234), 0x5679));
+        REQUIRE_FALSE(MAVSubnet(MAVAddress(0xFFFF), 0xFFFF) ==
+                      MAVSubnet(MAVAddress(0xFFFE), 0xFFFF));
+        REQUIRE_FALSE(MAVSubnet(MAVAddress(0xFFFF), 0xFFFF) ==
+                      MAVSubnet(MAVAddress(0xFFFF), 0xFFFE));
     }
     SECTION("with !=")
     {
-        REQUIRE(MAVSubnet(MAVAddress(0x0000), 0x0000) != MAVSubnet(MAVAddress(0x0001),
-                0x0000));
-        REQUIRE(MAVSubnet(MAVAddress(0x0000), 0x0000) != MAVSubnet(MAVAddress(0x0000),
-                0x0001));
-        REQUIRE(MAVSubnet(MAVAddress(0x1234), 0x5678) != MAVSubnet(MAVAddress(0x1235),
-                0x5678));
-        REQUIRE(MAVSubnet(MAVAddress(0x1234), 0x5678) != MAVSubnet(MAVAddress(0x1234),
-                0x5679));
-        REQUIRE(MAVSubnet(MAVAddress(0xFFFF), 0xFFFF) != MAVSubnet(MAVAddress(0xFFFE),
-                0xFFFF));
-        REQUIRE(MAVSubnet(MAVAddress(0xFFFF), 0xFFFF) != MAVSubnet(MAVAddress(0xFFFF),
-                0xFFFE));
-        REQUIRE_FALSE(MAVSubnet(MAVAddress(0x0000),
-                                0x0000) != MAVSubnet(MAVAddress(0x0000), 0x0000));
-        REQUIRE_FALSE(MAVSubnet(MAVAddress(0x1234),
-                                0x5678) != MAVSubnet(MAVAddress(0x1234), 0x5678));
-        REQUIRE_FALSE(MAVSubnet(MAVAddress(0xFFFF),
-                                0xFFFF) != MAVSubnet(MAVAddress(0xFFFF), 0xFFFF));
+        REQUIRE(MAVSubnet(MAVAddress(0x0000), 0x0000) !=
+                MAVSubnet(MAVAddress(0x0001), 0x0000));
+        REQUIRE(MAVSubnet(MAVAddress(0x0000), 0x0000) !=
+                MAVSubnet(MAVAddress(0x0000), 0x0001));
+        REQUIRE(MAVSubnet(MAVAddress(0x1234), 0x5678) !=
+                MAVSubnet(MAVAddress(0x1235), 0x5678));
+        REQUIRE(MAVSubnet(MAVAddress(0x1234), 0x5678) !=
+                MAVSubnet(MAVAddress(0x1234), 0x5679));
+        REQUIRE(MAVSubnet(MAVAddress(0xFFFF), 0xFFFF) !=
+                MAVSubnet(MAVAddress(0xFFFE), 0xFFFF));
+        REQUIRE(MAVSubnet(MAVAddress(0xFFFF), 0xFFFF) !=
+                MAVSubnet(MAVAddress(0xFFFF), 0xFFFE));
+        REQUIRE_FALSE(MAVSubnet(MAVAddress(0x0000), 0x0000) !=
+                      MAVSubnet(MAVAddress(0x0000), 0x0000));
+        REQUIRE_FALSE(MAVSubnet(MAVAddress(0x1234), 0x5678) !=
+                      MAVSubnet(MAVAddress(0x1234), 0x5678));
+        REQUIRE_FALSE(MAVSubnet(MAVAddress(0xFFFF), 0xFFFF) !=
+                      MAVSubnet(MAVAddress(0xFFFF), 0xFFFF));
     }
 }
 
 
-TEST_CASE("MAVSubnet's can be constructed from a MAVLink address and a numeric mask.",
-          "[MAVSubnet]")
+TEST_CASE("MAVSubnet's can be constructed from a MAVLink address "
+          "and a numeric mask.", "[MAVSubnet]")
 {
-    REQUIRE(MAVSubnet(MAVAddress(0x0000), 0x0000) == MAVSubnet(MAVAddress(0x0000),
-            0x0000));
-    REQUIRE(MAVSubnet(MAVAddress(0x1234), 0x5678) == MAVSubnet(MAVAddress(0x1234),
-            0x5678));
-    REQUIRE(MAVSubnet(MAVAddress(0xFFFF), 0xFFFF) == MAVSubnet(MAVAddress(0xFFFF),
-            0xFFFF));
+    REQUIRE(MAVSubnet(MAVAddress(0x0000), 0x0000) ==
+            MAVSubnet(MAVAddress(0x0000), 0x0000));
+    REQUIRE(MAVSubnet(MAVAddress(0x1234), 0x5678) ==
+            MAVSubnet(MAVAddress(0x1234), 0x5678));
+    REQUIRE(MAVSubnet(MAVAddress(0xFFFF), 0xFFFF) ==
+            MAVSubnet(MAVAddress(0xFFFF), 0xFFFF));
     SECTION("And ensures the mask is within range (0x0000 - 0xFFFF).")
     {
-        REQUIRE_THROWS_AS(MAVSubnet(MAVAddress(0x0000),
-                                    static_cast<unsigned int>(0x0000 - 1)),
-                          std::out_of_range);
-        REQUIRE_THROWS_AS(MAVSubnet(MAVAddress(0x0000), 0xFFFF + 1), std::out_of_range);
+        REQUIRE_THROWS_AS(
+            MAVSubnet(MAVAddress(0x0000),
+                      static_cast<unsigned int>(0x0000 - 1)),
+            std::out_of_range);
+        REQUIRE_THROWS_AS(
+                MAVSubnet(MAVAddress(0x0000), 0xFFFF + 1), std::out_of_range);
     }
 }
 
 
-TEST_CASE("MAVSubnet's can be constructed from a MAVLink address, system mask, and component mask.",
-          "[MAVSubnet]")
+TEST_CASE("MAVSubnet's can be constructed from a MAVLink address, "
+          "system mask, and component mask.", "[MAVSubnet]")
 {
-    REQUIRE(MAVSubnet(MAVAddress(0x0000), 0, 0) == MAVSubnet(MAVAddress(0x0000),
-            0));
-    REQUIRE(MAVSubnet(MAVAddress(0x0000), 255, 0) == MAVSubnet(MAVAddress(0x0000),
-            0xFF00));
-    REQUIRE(MAVSubnet(MAVAddress(0x0000), 0, 255) == MAVSubnet(MAVAddress(0x0000),
-            0x00FF));
-    REQUIRE(MAVSubnet(MAVAddress(0xFFFF), 255, 255) == MAVSubnet(MAVAddress(0xFFFF),
-            0xFFFF));
-    REQUIRE(MAVSubnet(MAVAddress(0x1234), 64, 128) == MAVSubnet(MAVAddress(0x1234),
-            0x4080));
-    REQUIRE(MAVSubnet(MAVAddress(0x1234), 128, 64) == MAVSubnet(MAVAddress(0x1234),
-            0x8040));
-    SECTION("And ensures the system and component masks are within range (0x00 - 0xFF).")
+    REQUIRE(MAVSubnet(MAVAddress(0x0000), 0, 0) ==
+            MAVSubnet(MAVAddress(0x0000), 0));
+    REQUIRE(MAVSubnet(MAVAddress(0x0000), 255, 0) ==
+            MAVSubnet(MAVAddress(0x0000), 0xFF00));
+    REQUIRE(MAVSubnet(MAVAddress(0x0000), 0, 255) ==
+            MAVSubnet(MAVAddress(0x0000), 0x00FF));
+    REQUIRE(MAVSubnet(MAVAddress(0xFFFF), 255, 255) ==
+            MAVSubnet(MAVAddress(0xFFFF), 0xFFFF));
+    REQUIRE(MAVSubnet(MAVAddress(0x1234), 64, 128) ==
+            MAVSubnet(MAVAddress(0x1234), 0x4080));
+    REQUIRE(MAVSubnet(MAVAddress(0x1234), 128, 64) ==
+            MAVSubnet(MAVAddress(0x1234), 0x8040));
+    SECTION("And ensures the system and component masks are within range "
+            "(0x00 - 0xFF).")
     {
-        REQUIRE_THROWS_AS(MAVSubnet(MAVAddress(0x0000), static_cast<unsigned int>(-1),
-                                    0),
-                          std::out_of_range);
-        REQUIRE_THROWS_AS(MAVSubnet(MAVAddress(0x0000), 0,
-                                    static_cast<unsigned int>(-1)),
-                          std::out_of_range);
-        REQUIRE_THROWS_AS(MAVSubnet(MAVAddress(0x0000), static_cast<unsigned int>(-1),
-                                    static_cast<unsigned int>(-1)),
-                          std::out_of_range);
-        REQUIRE_THROWS_AS(MAVSubnet(MAVAddress(0x0000), 256, 255), std::out_of_range);
-        REQUIRE_THROWS_AS(MAVSubnet(MAVAddress(0x0000), 255, 256), std::out_of_range);
-        REQUIRE_THROWS_AS(MAVSubnet(MAVAddress(0x0000), 256, 256), std::out_of_range);
+        auto addr = MAVAddress(0x0000);
+        // Errors
+        REQUIRE_THROWS_AS(
+            MAVSubnet(addr, static_cast<unsigned int>(-1), 0),
+            std::out_of_range);
+        REQUIRE_THROWS_AS(
+            MAVSubnet(addr, 0, static_cast<unsigned int>(-1)),
+            std::out_of_range);
+        REQUIRE_THROWS_AS(
+            MAVSubnet(addr,
+                      static_cast<unsigned int>(-1),
+                      static_cast<unsigned int>(-1)),
+            std::out_of_range);
+        REQUIRE_THROWS_AS(MAVSubnet(addr, 256, 255), std::out_of_range);
+        REQUIRE_THROWS_AS(MAVSubnet(addr, 255, 256), std::out_of_range);
+        REQUIRE_THROWS_AS(MAVSubnet(addr, 256, 256), std::out_of_range);
+        // Error messages.
+        REQUIRE_THROWS_WITH(
+            MAVSubnet(addr, 256, 255),
+            "System mask (0x100) is outside of the allowed range "
+            "(0x00 - 0xFF).");
+        REQUIRE_THROWS_WITH(
+            MAVSubnet(addr, 255, 256),
+            "Component mask (0x100) is outside of the allowed range "
+            "(0x00 - 0xFF).");
     }
 }
 
 
 TEST_CASE("MAVSubnet's can be constructed from strings.", "[MAVSubnet]")
 {
+    auto addr = MAVAddress(255, 16);
     SECTION("Using long notation.")
     {
-        REQUIRE(MAVSubnet("255.16:123.234") == MAVSubnet(MAVAddress(255, 16), 123,
-                234));
-        REQUIRE(MAVSubnet("255.16:0.0") == MAVSubnet(MAVAddress(255, 16), 0, 0));
-        REQUIRE(MAVSubnet("255.16:128.0") == MAVSubnet(MAVAddress(255, 16), 128, 0));
-        REQUIRE(MAVSubnet("255.16:0.240") == MAVSubnet(MAVAddress(255, 16), 0, 240));
-        REQUIRE(MAVSubnet("255.16:128.240") == MAVSubnet(MAVAddress(255, 16), 128,
-                240));
+        REQUIRE(MAVSubnet("255.16:123.234") == MAVSubnet(addr, 123, 234));
+        REQUIRE(MAVSubnet("255.16:0.0") == MAVSubnet(addr, 0, 0));
+        REQUIRE(MAVSubnet("255.16:128.0") == MAVSubnet(addr, 128, 0));
+        REQUIRE(MAVSubnet("255.16:0.240") == MAVSubnet(addr, 0, 240));
+        REQUIRE(MAVSubnet("255.16:128.240") == MAVSubnet(addr, 128, 240));
     }
     SECTION("Using forward slash notation.")
     {
-        REQUIRE(MAVSubnet("255.16/0") == MAVSubnet(MAVAddress(255, 16),
-                0b0000000000000000));
-        REQUIRE(MAVSubnet("255.16/1") == MAVSubnet(MAVAddress(255, 16),
-                0b1000000000000000));
-        REQUIRE(MAVSubnet("255.16/2") == MAVSubnet(MAVAddress(255, 16),
-                0b1100000000000000));
-        REQUIRE(MAVSubnet("255.16/3") == MAVSubnet(MAVAddress(255, 16),
-                0b1110000000000000));
-        REQUIRE(MAVSubnet("255.16/4") == MAVSubnet(MAVAddress(255, 16),
-                0b1111000000000000));
-        REQUIRE(MAVSubnet("255.16/5") == MAVSubnet(MAVAddress(255, 16),
-                0b1111100000000000));
-        REQUIRE(MAVSubnet("255.16/6") == MAVSubnet(MAVAddress(255, 16),
-                0b1111110000000000));
-        REQUIRE(MAVSubnet("255.16/7") == MAVSubnet(MAVAddress(255, 16),
-                0b1111111000000000));
-        REQUIRE(MAVSubnet("255.16/8") == MAVSubnet(MAVAddress(255, 16),
-                0b1111111100000000));
-        REQUIRE(MAVSubnet("255.16/9") == MAVSubnet(MAVAddress(255, 16),
-                0b1111111110000000));
-        REQUIRE(MAVSubnet("255.16/10") == MAVSubnet(MAVAddress(255, 16),
-                0b1111111111000000));
-        REQUIRE(MAVSubnet("255.16/11") == MAVSubnet(MAVAddress(255, 16),
-                0b1111111111100000));
-        REQUIRE(MAVSubnet("255.16/12") == MAVSubnet(MAVAddress(255, 16),
-                0b1111111111110000));
-        REQUIRE(MAVSubnet("255.16/13") == MAVSubnet(MAVAddress(255, 16),
-                0b1111111111111000));
-        REQUIRE(MAVSubnet("255.16/14") == MAVSubnet(MAVAddress(255, 16),
-                0b1111111111111100));
-        REQUIRE(MAVSubnet("255.16/15") == MAVSubnet(MAVAddress(255, 16),
-                0b1111111111111110));
-        REQUIRE(MAVSubnet("255.16/16") == MAVSubnet(MAVAddress(255, 16),
-                0b1111111111111111));
+        REQUIRE(MAVSubnet("255.16/0") == MAVSubnet(addr, 0b0000000000000000));
+        REQUIRE(MAVSubnet("255.16/1") == MAVSubnet(addr, 0b1000000000000000));
+        REQUIRE(MAVSubnet("255.16/2") == MAVSubnet(addr, 0b1100000000000000));
+        REQUIRE(MAVSubnet("255.16/3") == MAVSubnet(addr, 0b1110000000000000));
+        REQUIRE(MAVSubnet("255.16/4") == MAVSubnet(addr, 0b1111000000000000));
+        REQUIRE(MAVSubnet("255.16/5") == MAVSubnet(addr, 0b1111100000000000));
+        REQUIRE(MAVSubnet("255.16/6") == MAVSubnet(addr, 0b1111110000000000));
+        REQUIRE(MAVSubnet("255.16/7") == MAVSubnet(addr, 0b1111111000000000));
+        REQUIRE(MAVSubnet("255.16/8") == MAVSubnet(addr, 0b1111111100000000));
+        REQUIRE(MAVSubnet("255.16/9") == MAVSubnet(addr, 0b1111111110000000));
+        REQUIRE(MAVSubnet("255.16/10") == MAVSubnet(addr, 0b1111111111000000));
+        REQUIRE(MAVSubnet("255.16/11") == MAVSubnet(addr, 0b1111111111100000));
+        REQUIRE(MAVSubnet("255.16/12") == MAVSubnet(addr, 0b1111111111110000));
+        REQUIRE(MAVSubnet("255.16/13") == MAVSubnet(addr, 0b1111111111111000));
+        REQUIRE(MAVSubnet("255.16/14") == MAVSubnet(addr, 0b1111111111111100));
+        REQUIRE(MAVSubnet("255.16/15") == MAVSubnet(addr, 0b1111111111111110));
+        REQUIRE(MAVSubnet("255.16/16") == MAVSubnet(addr, 0b1111111111111111));
     }
     SECTION("Using backslash notation.")
     {
-        REQUIRE(MAVSubnet("255.16\\0") == MAVSubnet(MAVAddress(255, 16),
-                0b0000000000000000));
-        REQUIRE(MAVSubnet("255.16\\1") == MAVSubnet(MAVAddress(255, 16),
-                0b0000000010000000));
-        REQUIRE(MAVSubnet("255.16\\2") == MAVSubnet(MAVAddress(255, 16),
-                0b0000000011000000));
-        REQUIRE(MAVSubnet("255.16\\3") == MAVSubnet(MAVAddress(255, 16),
-                0b0000000011100000));
-        REQUIRE(MAVSubnet("255.16\\4") == MAVSubnet(MAVAddress(255, 16),
-                0b0000000011110000));
-        REQUIRE(MAVSubnet("255.16\\5") == MAVSubnet(MAVAddress(255, 16),
-                0b0000000011111000));
-        REQUIRE(MAVSubnet("255.16\\6") == MAVSubnet(MAVAddress(255, 16),
-                0b0000000011111100));
-        REQUIRE(MAVSubnet("255.16\\7") == MAVSubnet(MAVAddress(255, 16),
-                0b0000000011111110));
-        REQUIRE(MAVSubnet("255.16\\8") == MAVSubnet(MAVAddress(255, 16),
-                0b0000000011111111));
+        REQUIRE(MAVSubnet("255.16\\0") == MAVSubnet(addr, 0b0000000000000000));
+        REQUIRE(MAVSubnet("255.16\\1") == MAVSubnet(addr, 0b0000000010000000));
+        REQUIRE(MAVSubnet("255.16\\2") == MAVSubnet(addr, 0b0000000011000000));
+        REQUIRE(MAVSubnet("255.16\\3") == MAVSubnet(addr, 0b0000000011100000));
+        REQUIRE(MAVSubnet("255.16\\4") == MAVSubnet(addr, 0b0000000011110000));
+        REQUIRE(MAVSubnet("255.16\\5") == MAVSubnet(addr, 0b0000000011111000));
+        REQUIRE(MAVSubnet("255.16\\6") == MAVSubnet(addr, 0b0000000011111100));
+        REQUIRE(MAVSubnet("255.16\\7") == MAVSubnet(addr, 0b0000000011111110));
+        REQUIRE(MAVSubnet("255.16\\8") == MAVSubnet(addr, 0b0000000011111111));
     }
     SECTION("And ensures the subnet string is valid.")
     {
+        // Errors
         REQUIRE_THROWS_AS(MAVSubnet("255.16 255.256"), std::invalid_argument);
         REQUIRE_THROWS_AS(MAVSubnet("255.16-256.255"), std::invalid_argument);
         REQUIRE_THROWS_AS(MAVSubnet("255.16+256.255"), std::invalid_argument);
@@ -208,21 +198,80 @@ TEST_CASE("MAVSubnet's can be constructed from strings.", "[MAVSubnet]")
         REQUIRE_THROWS_AS(MAVSubnet("255.16:0.+1"), std::invalid_argument);
         REQUIRE_THROWS_AS(MAVSubnet("255.16:-1.0"), std::invalid_argument);
         REQUIRE_THROWS_AS(MAVSubnet("255.16:0.-1"), std::invalid_argument);
+        // Error messages.
+        REQUIRE_THROWS_WITH(
+            MAVSubnet("255.16 255.256"),
+            "Invalid MAVLink subnet: \"255.16 255.256\".");
+        REQUIRE_THROWS_WITH(
+            MAVSubnet("255.16-256.255"),
+            "Invalid MAVLink subnet: \"255.16-256.255\".");
+        REQUIRE_THROWS_WITH(
+            MAVSubnet("255.16+256.255"),
+            "Invalid MAVLink subnet: \"255.16+256.255\".");
+        REQUIRE_THROWS_WITH(
+            MAVSubnet("255.16:1"), "Invalid MAVLink subnet: \"255.16:1\".");
+        REQUIRE_THROWS_WITH(
+            MAVSubnet("255.16:1."), "Invalid MAVLink subnet: \"255.16:1.\".");
+        REQUIRE_THROWS_WITH(
+            MAVSubnet("255.16:1.2."),
+            "Invalid MAVLink subnet: \"255.16:1.2.\".");
+        REQUIRE_THROWS_WITH(
+            MAVSubnet("255.16:1.2.3"),
+            "Invalid MAVLink subnet: \"255.16:1.2.3\".");
+        REQUIRE_THROWS_WITH(
+            MAVSubnet("255.16:a.2.3"),
+            "Invalid MAVLink subnet: \"255.16:a.2.3\".");
+        REQUIRE_THROWS_WITH(
+            MAVSubnet("255.16:1.b.3"),
+            "Invalid MAVLink subnet: \"255.16:1.b.3\".");
+        REQUIRE_THROWS_WITH(
+            MAVSubnet("255.16:1.2.c"),
+            "Invalid MAVLink subnet: \"255.16:1.2.c\".");
+        REQUIRE_THROWS_WITH(
+            MAVSubnet("255.16:+1.0"),
+            "Invalid MAVLink subnet: \"255.16:+1.0\".");
+        REQUIRE_THROWS_WITH(
+            MAVSubnet("255.16:0.+1"),
+            "Invalid MAVLink subnet: \"255.16:0.+1\".");
+        REQUIRE_THROWS_WITH(
+            MAVSubnet("255.16:-1.0"),
+            "Invalid MAVLink subnet: \"255.16:-1.0\".");
+        REQUIRE_THROWS_WITH(
+            MAVSubnet("255.16:0.-1"),
+            "Invalid MAVLink subnet: \"255.16:0.-1\".");
     }
     SECTION("And ensures mask is within range.")
     {
-        REQUIRE_THROWS_AS(MAVSubnet("255.16/256.255"), std::out_of_range);
-        REQUIRE_THROWS_AS(MAVSubnet("255.16/255.256"), std::out_of_range);
+        // Errors
+        REQUIRE_THROWS_AS(MAVSubnet("255.16:256.255"), std::out_of_range);
+        REQUIRE_THROWS_AS(MAVSubnet("255.16:255.256"), std::out_of_range);
+        // Error messages.
+        REQUIRE_THROWS_WITH(
+            MAVSubnet("255.16:256.255"),
+            "System ID (256) is outside of the allowed range (0 - 255).");
+        REQUIRE_THROWS_WITH(
+            MAVSubnet("255.16:255.256"),
+            "Component ID (256) is outside of the allowed range (0 - 255).");
     }
     SECTION("And ensures forward slash mask is within range.")
     {
+        // Errors
         REQUIRE_THROWS_AS(MAVSubnet("255.16/-1"), std::out_of_range);
         REQUIRE_THROWS_AS(MAVSubnet("255.16/17"), std::out_of_range);
+        // Error messages.
+        REQUIRE_THROWS_WITH(
+            MAVSubnet("255.16/17"),
+            "Forward slash mask (17) is outside of allowed range (0 - 16).");
     }
     SECTION("And ensures backslash mask is within range.")
     {
+        // Errors
+        REQUIRE_THROWS_AS(MAVSubnet("255.16/-1"), std::out_of_range);
         REQUIRE_THROWS_AS(MAVSubnet("255.16\\-1"), std::out_of_range);
-        REQUIRE_THROWS_AS(MAVSubnet("255.16\\9"), std::out_of_range);
+        // Error messages.
+        REQUIRE_THROWS_WITH(
+            MAVSubnet("255.16\\9"),
+            "Backslash mask (9) is outside of allowed range (0 - 8).");
     }
 }
 
@@ -251,37 +300,39 @@ TEST_CASE("MAVSubnet's are assignable.", "[MAVSubnet]")
 
 TEST_CASE("MAVSubnet's are printable", "[MAVSubnet]")
 {
-    REQUIRE(str(MAVSubnet(MAVAddress(255, 16), 123, 234)) == "255.16:123.234");
-    REQUIRE(str(MAVSubnet(MAVAddress(255, 16), 128, 240)) == "255.16:128.240");
-    REQUIRE(str(MAVSubnet(MAVAddress(255, 16), 0b0000000000000000)) == "255.16/0");
-    REQUIRE(str(MAVSubnet(MAVAddress(255, 16), 0b1000000000000000)) == "255.16/1");
-    REQUIRE(str(MAVSubnet(MAVAddress(255, 16), 0b1100000000000000)) == "255.16/2");
-    REQUIRE(str(MAVSubnet(MAVAddress(255, 16), 0b1110000000000000)) == "255.16/3");
-    REQUIRE(str(MAVSubnet(MAVAddress(255, 16), 0b1111000000000000)) == "255.16/4");
-    REQUIRE(str(MAVSubnet(MAVAddress(255, 16), 0b1111100000000000)) == "255.16/5");
-    REQUIRE(str(MAVSubnet(MAVAddress(255, 16), 0b1111110000000000)) == "255.16/6");
-    REQUIRE(str(MAVSubnet(MAVAddress(255, 16), 0b1111111000000000)) == "255.16/7");
-    REQUIRE(str(MAVSubnet(MAVAddress(255, 16), 0b1111111100000000)) == "255.16/8");
-    REQUIRE(str(MAVSubnet(MAVAddress(255, 16), 0b1111111110000000)) == "255.16/9");
-    REQUIRE(str(MAVSubnet(MAVAddress(255, 16), 0b1111111111000000)) == "255.16/10");
-    REQUIRE(str(MAVSubnet(MAVAddress(255, 16), 0b1111111111100000)) == "255.16/11");
-    REQUIRE(str(MAVSubnet(MAVAddress(255, 16), 0b1111111111110000)) == "255.16/12");
-    REQUIRE(str(MAVSubnet(MAVAddress(255, 16), 0b1111111111111000)) == "255.16/13");
-    REQUIRE(str(MAVSubnet(MAVAddress(255, 16), 0b1111111111111100)) == "255.16/14");
-    REQUIRE(str(MAVSubnet(MAVAddress(255, 16), 0b1111111111111110)) == "255.16/15");
-    REQUIRE(str(MAVSubnet(MAVAddress(255, 16), 0b1111111111111111)) == "255.16/16");
-    REQUIRE(str(MAVSubnet(MAVAddress(255, 16), 0b0000000010000000)) == "255.16\\1");
-    REQUIRE(str(MAVSubnet(MAVAddress(255, 16), 0b0000000011000000)) == "255.16\\2");
-    REQUIRE(str(MAVSubnet(MAVAddress(255, 16), 0b0000000011100000)) == "255.16\\3");
-    REQUIRE(str(MAVSubnet(MAVAddress(255, 16), 0b0000000011110000)) == "255.16\\4");
-    REQUIRE(str(MAVSubnet(MAVAddress(255, 16), 0b0000000011111000)) == "255.16\\5");
-    REQUIRE(str(MAVSubnet(MAVAddress(255, 16), 0b0000000011111100)) == "255.16\\6");
-    REQUIRE(str(MAVSubnet(MAVAddress(255, 16), 0b0000000011111110)) == "255.16\\7");
-    REQUIRE(str(MAVSubnet(MAVAddress(255, 16), 0b0000000011111111)) == "255.16\\8");
+    auto addr = MAVAddress(255, 16);
+    REQUIRE(str(MAVSubnet(addr, 123, 234)) == "255.16:123.234");
+    REQUIRE(str(MAVSubnet(addr, 128, 240)) == "255.16:128.240");
+    REQUIRE(str(MAVSubnet(addr, 0b0000000000000000)) == "255.16/0");
+    REQUIRE(str(MAVSubnet(addr, 0b1000000000000000)) == "255.16/1");
+    REQUIRE(str(MAVSubnet(addr, 0b1100000000000000)) == "255.16/2");
+    REQUIRE(str(MAVSubnet(addr, 0b1110000000000000)) == "255.16/3");
+    REQUIRE(str(MAVSubnet(addr, 0b1111000000000000)) == "255.16/4");
+    REQUIRE(str(MAVSubnet(addr, 0b1111100000000000)) == "255.16/5");
+    REQUIRE(str(MAVSubnet(addr, 0b1111110000000000)) == "255.16/6");
+    REQUIRE(str(MAVSubnet(addr, 0b1111111000000000)) == "255.16/7");
+    REQUIRE(str(MAVSubnet(addr, 0b1111111100000000)) == "255.16/8");
+    REQUIRE(str(MAVSubnet(addr, 0b1111111110000000)) == "255.16/9");
+    REQUIRE(str(MAVSubnet(addr, 0b1111111111000000)) == "255.16/10");
+    REQUIRE(str(MAVSubnet(addr, 0b1111111111100000)) == "255.16/11");
+    REQUIRE(str(MAVSubnet(addr, 0b1111111111110000)) == "255.16/12");
+    REQUIRE(str(MAVSubnet(addr, 0b1111111111111000)) == "255.16/13");
+    REQUIRE(str(MAVSubnet(addr, 0b1111111111111100)) == "255.16/14");
+    REQUIRE(str(MAVSubnet(addr, 0b1111111111111110)) == "255.16/15");
+    REQUIRE(str(MAVSubnet(addr, 0b1111111111111111)) == "255.16/16");
+    REQUIRE(str(MAVSubnet(addr, 0b0000000010000000)) == "255.16\\1");
+    REQUIRE(str(MAVSubnet(addr, 0b0000000011000000)) == "255.16\\2");
+    REQUIRE(str(MAVSubnet(addr, 0b0000000011100000)) == "255.16\\3");
+    REQUIRE(str(MAVSubnet(addr, 0b0000000011110000)) == "255.16\\4");
+    REQUIRE(str(MAVSubnet(addr, 0b0000000011111000)) == "255.16\\5");
+    REQUIRE(str(MAVSubnet(addr, 0b0000000011111100)) == "255.16\\6");
+    REQUIRE(str(MAVSubnet(addr, 0b0000000011111110)) == "255.16\\7");
+    REQUIRE(str(MAVSubnet(addr, 0b0000000011111111)) == "255.16\\8");
 }
 
 
-TEST_CASE("The 'contains' determines if a MAVLink address is in the subnet.",
+TEST_CASE("The 'contains' method determines if a MAVLink address "
+          "is in the subnet.",
           "[MAVSubnet]")
 {
     REQUIRE(MAVSubnet("0.0:0.0").contains(MAVAddress("0.0")));

--- a/test/test_MAVSubnet.cpp
+++ b/test/test_MAVSubnet.cpp
@@ -15,8 +15,10 @@
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-#include <catch.hpp>
+#include <utility>
 #include <stdexcept>
+
+#include <catch.hpp>
 
 #include "util.hpp"
 #include "MAVAddress.hpp"
@@ -278,8 +280,8 @@ TEST_CASE("MAVSubnet's can be constructed from strings.", "[MAVSubnet]")
 
 TEST_CASE("MAVSubnet's are copyable.", "[MAVSubnet]")
 {
-    MAVSubnet a(MAVAddress(0x0000), 0);
-    MAVSubnet b(MAVAddress(0xFFFF), 255);
+    MAVSubnet a(MAVAddress(0x0000), 0, 0);
+    MAVSubnet b(MAVAddress(0xFFFF), 255, 255);
     MAVSubnet a_copy = a;
     MAVSubnet b_copy(b);
     REQUIRE(&a != &a_copy);
@@ -289,11 +291,33 @@ TEST_CASE("MAVSubnet's are copyable.", "[MAVSubnet]")
 }
 
 
+TEST_CASE("MAVSubnet's are movable.", "[MAVSubnet]")
+{
+    MAVSubnet a(MAVAddress(0x0000), 0, 0);
+    MAVSubnet b(MAVAddress(0xFFFF), 255, 255);
+    MAVSubnet a_moved = std::move(a);
+    MAVSubnet b_moved(std::move(b));
+    REQUIRE(a_moved == MAVSubnet(MAVAddress(0x0000), 0, 0));
+    REQUIRE(b_moved == MAVSubnet(MAVAddress(0xFFFF), 255, 255));
+}
+
+
 TEST_CASE("MAVSubnet's are assignable.", "[MAVSubnet]")
 {
     MAVSubnet a(MAVAddress(0x0000), 0, 0);
+    MAVSubnet b(MAVAddress(0xFFFF), 255, 255);
     REQUIRE(a == MAVSubnet(MAVAddress(0x0000), 0, 0));
-    a = MAVSubnet(MAVAddress(0xFFFF), 255, 255);
+    a = b;
+    REQUIRE(a == MAVSubnet(MAVAddress(0xFFFF), 255, 255));
+}
+
+
+TEST_CASE("MAVSubnet's are assignable (by move semantics).", "[MAVSubnet]")
+{
+    MAVSubnet a(MAVAddress(0x0000), 0, 0);
+    MAVSubnet b(MAVAddress(0xFFFF), 255, 255);
+    REQUIRE(a == MAVSubnet(MAVAddress(0x0000), 0, 0));
+    a = std::move(b);
     REQUIRE(a == MAVSubnet(MAVAddress(0xFFFF), 255, 255));
 }
 

--- a/test/test_Packet.cpp
+++ b/test/test_Packet.cpp
@@ -219,7 +219,8 @@ TEST_CASE("Packet's are assignable.", "[Packet]")
     std::vector<uint8_t> data = {1, 3, 3, 7};
     auto conn = std::make_shared<ConnectionTestClass>();
     PacketTestClass packet(data, conn, -10);
-    PacketTestClass packet_to_copy({}, std::weak_ptr<ConnectionTestClass>(), 10);
+    PacketTestClass packet_to_copy(
+        {}, std::weak_ptr<ConnectionTestClass>(), 10);
     REQUIRE(packet.data() == data);
     REQUIRE(packet.connection().lock() == conn);
     REQUIRE(packet.priority() == -10);
@@ -235,7 +236,8 @@ TEST_CASE("Packet's are assignable (by move semantics).", "[Packet]")
     std::vector<uint8_t> data = {1, 3, 3, 7};
     auto conn = std::make_shared<ConnectionTestClass>();
     PacketTestClass packet(data, conn, -10);
-    PacketTestClass packet_to_move({}, std::weak_ptr<ConnectionTestClass>(), 10);
+    PacketTestClass packet_to_move(
+        {}, std::weak_ptr<ConnectionTestClass>(), 10);
     REQUIRE(packet.data() == data);
     REQUIRE(packet.connection().lock() == conn);
     REQUIRE(packet.priority() == -10);

--- a/test/test_PacketVersion1.cpp
+++ b/test/test_PacketVersion1.cpp
@@ -377,7 +377,8 @@ TEST_CASE("PacketVersion1's are assignable.", "[PacketVersion1]")
     auto ping = to_vector(Ping());
     auto conn = std::make_shared<ConnectionTestClass>();
     PacketVersion1 packet(heartbeat, conn, -10);
-    PacketVersion1 packet_to_copy(ping, std::weak_ptr<ConnectionTestClass>(), 10);
+    PacketVersion1 packet_to_copy(
+        ping, std::weak_ptr<ConnectionTestClass>(), 10);
     REQUIRE(packet.data() == heartbeat);
     REQUIRE(packet.connection().lock() == conn);
     REQUIRE(packet.priority() == -10);
@@ -395,7 +396,8 @@ TEST_CASE("PacketVersion1's are assignable (with move semantics).",
     auto ping = to_vector(Ping());
     auto conn = std::make_shared<ConnectionTestClass>();
     PacketVersion1 packet(heartbeat, conn, -10);
-    PacketVersion1 packet_to_move(ping, std::weak_ptr<ConnectionTestClass>(), 10);
+    PacketVersion1 packet_to_move(
+        ping, std::weak_ptr<ConnectionTestClass>(), 10);
     REQUIRE(packet.data() == heartbeat);
     REQUIRE(packet.connection().lock() == conn);
     REQUIRE(packet.priority() == -10);

--- a/test/test_util.cpp
+++ b/test/test_util.cpp
@@ -18,10 +18,8 @@
 #include <vector>
 #include <catch.hpp>
 #include <fakeit.hpp>
+
 #include "util.hpp"
-
-
-using namespace fakeit;
 
 
 TEST_CASE("to_bytes: Convert numeric types to bytes.", "[to_bytes]")
@@ -30,88 +28,87 @@ TEST_CASE("to_bytes: Convert numeric types to bytes.", "[to_bytes]")
     {
         auto bytes = to_bytes(static_cast<char>(0x89));
         REQUIRE(bytes.size() >= 1);
-        REQUIRE(bytes[0] == 0X89);
+        REQUIRE(bytes[0] == 0x89);
     }
     SECTION("unsigned char's can be converted to at least 1 byte")
     {
         auto bytes = to_bytes(static_cast<unsigned char>(0x89u));
         REQUIRE(bytes.size() >= 1);
-        REQUIRE(bytes[0] == 0X89);
+        REQUIRE(bytes[0] == 0x89);
     }
     SECTION("short's can be converted to at least 2 bytes")
     {
         auto bytes = to_bytes(static_cast<short>(0xFACE));
         REQUIRE(bytes.size() >= 2);
-        REQUIRE(bytes[0] == 0XCE);
-        REQUIRE(bytes[1] == 0XFA);
+        REQUIRE(bytes[0] == 0xCE);
+        REQUIRE(bytes[1] == 0xFA);
     }
     SECTION("unsigned short's can be converted to at least 2 bytes")
     {
         auto bytes = to_bytes(static_cast<unsigned short>(0xFACEu));
         REQUIRE(bytes.size() >= 2);
-        REQUIRE(bytes[0] == 0XCE);
-        REQUIRE(bytes[1] == 0XFA);
+        REQUIRE(bytes[0] == 0xCE);
+        REQUIRE(bytes[1] == 0xFA);
     }
     SECTION("int's can be converted to at least 2 bytes")
     {
         auto bytes = to_bytes(static_cast<int>(0xFACE));
         REQUIRE(bytes.size() >= 2);
-        REQUIRE(bytes[0] == 0XCE);
-        REQUIRE(bytes[1] == 0XFA);
+        REQUIRE(bytes[0] == 0xCE);
+        REQUIRE(bytes[1] == 0xFA);
     }
     SECTION("unsigned int's can be converted to at least 2 bytes")
     {
         auto bytes = to_bytes(static_cast<unsigned int>(0xFACEu));
         REQUIRE(bytes.size() >= 2);
-        REQUIRE(bytes[0] == 0XCE);
-        REQUIRE(bytes[1] == 0XFA);
+        REQUIRE(bytes[0] == 0xCE);
+        REQUIRE(bytes[1] == 0xFA);
     }
     SECTION("long's can be converted to at least 4 bytes")
     {
         auto bytes = to_bytes(static_cast<long>(0xBA5EBA11));
         REQUIRE(bytes.size() >= 4);
-        REQUIRE(bytes[0] == 0X11);
-        REQUIRE(bytes[1] == 0XBA);
-        REQUIRE(bytes[2] == 0X5E);
-        REQUIRE(bytes[3] == 0XBA);
+        REQUIRE(bytes[0] == 0x11);
+        REQUIRE(bytes[1] == 0xBA);
+        REQUIRE(bytes[2] == 0x5E);
+        REQUIRE(bytes[3] == 0xBA);
     }
     SECTION("unsigned long's can be converted to at least 4 bytes")
     {
         unsigned long i = 0xBA5EBA11;
         REQUIRE(0xBA5EBA11 == i);
         auto bytes = to_bytes(static_cast<unsigned long>(0xBA5EBA11u));
-        // std::array<unsigned char, 4> bytes = to_bytes<unsigned char, unsigned long>(i);
         REQUIRE(bytes.size() >= 4);
-        // REQUIRE(bytes[0] == 0X11);
-        // REQUIRE(bytes[1] == 0XBA);
-        // REQUIRE(bytes[2] == 0X5E);
-        // REQUIRE(bytes[3] == 0XBA);
+        REQUIRE(bytes[0] == 0x11);
+        REQUIRE(bytes[1] == 0xBA);
+        REQUIRE(bytes[2] == 0x5E);
+        REQUIRE(bytes[3] == 0xBA);
     }
     SECTION("long long's can be converted to at least 8 bytes")
     {
         auto bytes = to_bytes(static_cast<long>(0x0123456789ABCDEF));
         REQUIRE(bytes.size() >= 8);
-        REQUIRE(bytes[0] == 0XEF);
-        REQUIRE(bytes[1] == 0XCD);
-        REQUIRE(bytes[2] == 0XAB);
-        REQUIRE(bytes[3] == 0X89);
-        REQUIRE(bytes[4] == 0X67);
-        REQUIRE(bytes[5] == 0X45);
-        REQUIRE(bytes[6] == 0X23);
-        REQUIRE(bytes[7] == 0X01);
+        REQUIRE(bytes[0] == 0xEF);
+        REQUIRE(bytes[1] == 0xCD);
+        REQUIRE(bytes[2] == 0xAB);
+        REQUIRE(bytes[3] == 0x89);
+        REQUIRE(bytes[4] == 0x67);
+        REQUIRE(bytes[5] == 0x45);
+        REQUIRE(bytes[6] == 0x23);
+        REQUIRE(bytes[7] == 0x01);
     }
     SECTION("unsigned long long's can be converted to at least 8 bytes")
     {
         auto bytes = to_bytes(static_cast<unsigned long>(0x0123456789ABCDEFu));
         REQUIRE(bytes.size() >= 8);
-        REQUIRE(bytes[0] == 0XEF);
-        REQUIRE(bytes[1] == 0XCD);
-        REQUIRE(bytes[2] == 0XAB);
-        REQUIRE(bytes[3] == 0X89);
-        REQUIRE(bytes[4] == 0X67);
-        REQUIRE(bytes[5] == 0X45);
-        REQUIRE(bytes[6] == 0X23);
-        REQUIRE(bytes[7] == 0X01);
+        REQUIRE(bytes[0] == 0xEF);
+        REQUIRE(bytes[1] == 0xCD);
+        REQUIRE(bytes[2] == 0xAB);
+        REQUIRE(bytes[3] == 0x89);
+        REQUIRE(bytes[4] == 0x67);
+        REQUIRE(bytes[5] == 0x45);
+        REQUIRE(bytes[6] == 0x23);
+        REQUIRE(bytes[7] == 0x01);
     }
 }
 
@@ -121,36 +118,4 @@ TEST_CASE("str: Convert printable types to strings.", "[to_string]")
     REQUIRE(str(256) == "256");
     REQUIRE(str(3.14159) == "3.14159");
     REQUIRE(str("Hello world") == "Hello world");
-}
-
-
-TEST_CASE("capital_case capitalizes first character of a string.",
-          "[captal_case]")
-{
-    REQUIRE(capital_case("the quick brown fox.") == "The quick brown fox.");
-}
-
-
-TEST_CASE("fakeit example")
-{
-    // Sample interface.
-    struct SomeInterface
-    {
-        virtual int is_positive(int) = 0;
-        virtual int capital_case(std::string) = 0;
-        virtual ~SomeInterface() = 0;
-    };
-    Mock<SomeInterface> mock;
-    When(Method(mock, is_positive).Using(Gt(0))).AlwaysReturn(true);
-    When(Method(mock, is_positive).Using(Le(0))).AlwaysReturn(false);
-    When(Method(mock, capital_case)).Return(0, 1, 2);
-    // Get rerference to the interface and test.
-    SomeInterface &i = mock.get();
-    REQUIRE(i.is_positive(-1) == false);
-    REQUIRE(i.is_positive(0) == false);
-    REQUIRE(i.is_positive(1) == true);
-    i.capital_case("hello world");
-    // Verify methods were called.
-    Verify(Method(mock, is_positive)).Exactly(3);
-    Verify(Method(mock, capital_case));
 }


### PR DESCRIPTION
Cleanup older classes.  Mainly ensuring line width is 80 characters or below and improving any tests if necessary.  Also, add move semantics (or rather move semantics documentation).

The classes cleaned up are:

- [x] IPAddress
- [x] DNSLookupError
- [x] MAVAddress
- [x] MAVSubnet